### PR TITLE
fix(geocoder): return correct error messages

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,8 @@
+/**
+ * Mapping from error codes to error messages
+ */
+export default {
+  'ENOTFOUND': 'Could not connect to the Google Maps API (DNS)',
+  'ECONNREFUSED': 'Could not connect to the Google Maps API',
+  '403': 'Wrong clientId or privateKey'
+};

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -3,6 +3,7 @@
 import Cache from './cache';
 import isEmpty from 'amp-is-empty';
 import GoogleGeocoder from './lib/google-geocoder';
+import Errors from './errors';
 
 /**
  * Geocoder instance
@@ -79,7 +80,10 @@ export default class Geocoder {
       this.currentRequests--;
 
       if (error) {
-        return reject(new Error('Wrong clientId or privateKey'));
+        const errorMessage = Errors[error.code] ||
+          'Google Maps API error: ' + error.code;
+
+        return reject(new Error(errorMessage));
       }
 
       if (response.status === 'OVER_QUERY_LIMIT') {

--- a/test/geocoder-test.js
+++ b/test/geocoder-test.js
@@ -106,9 +106,13 @@ describe('Testing geocoder', function() {
     }
   );
 
-  it('should throw error when geocoder returns error', function(done) {
+  it('should throw authentication error when geocoder returns error', function(done) {
     const mockAddress = 'Hamburg',
-      geocodeFunction = getGeocodeFunction({error: 'error'}),
+      geocodeFunction = getGeocodeFunction({
+        error: {
+          code: 403
+        }
+      }),
       geoCoderInterface = getGeocoderInterface(geocodeFunction),
       geocoder = new Geocoder(
         {
@@ -122,6 +126,30 @@ describe('Testing geocoder', function() {
       .catch(error => {
         should(error).be.an.Error;
         should(error.message).equal('Wrong clientId or privateKey');
+      })
+      .then(done, done);
+  });
+
+  it('should throw connection error when geocoder returns error', function(done) {
+    const mockAddress = 'Hamburg',
+      geocodeFunction = getGeocodeFunction({
+        error: {
+          code: 'ECONNREFUSED'
+        }
+      }),
+      geoCoderInterface = getGeocoderInterface(geocodeFunction),
+      geocoder = new Geocoder(
+        {
+          clientId: 'dummy',
+          privateKey: 'dummy'
+        },
+        geoCoderInterface,
+        MockCache);
+
+    geocoder.geocodeAddress(mockAddress)
+      .catch(error => {
+        should(error).be.an.Error;
+        should(error.message).equal('Could not connect to the Google Maps API');
       })
       .then(done, done);
   });

--- a/test/geocoder-test.js
+++ b/test/geocoder-test.js
@@ -106,7 +106,7 @@ describe('Testing geocoder', function() {
     }
   );
 
-  it('should throw authentication error when geocoder returns error', function(done) {
+  it('should throw authentication error when appropriate', function(done) {
     const mockAddress = 'Hamburg',
       geocodeFunction = getGeocodeFunction({
         error: {
@@ -130,7 +130,7 @@ describe('Testing geocoder', function() {
       .then(done, done);
   });
 
-  it('should throw connection error when geocoder returns error', function(done) {
+  it('should throw connection error when appropriate', function(done) {
     const mockAddress = 'Hamburg',
       geocodeFunction = getGeocodeFunction({
         error: {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -19,28 +19,25 @@ describe('Helper functions ', () => {
     });
 
     it(`should return a geocoder interface which returna geocoder with
-      a given geocode function`, () => {
-        const mockGeocodeFunction = () => {},
-          geocoderInterface = getGeocoderInterface(mockGeocodeFunction),
-          geocoder = geocoderInterface.init(),
-          geocodeFunction = geocoder.geocode;
-        should(geocodeFunction).deepEqual(mockGeocodeFunction);
-      }
-    );
+    a given geocode function`, () => {
+      const mockGeocodeFunction = () => {},
+        geocoderInterface = getGeocoderInterface(mockGeocodeFunction),
+        geocoder = geocoderInterface.init(),
+        geocodeFunction = geocoder.geocode;
+      should(geocodeFunction).deepEqual(mockGeocodeFunction);
+    });
 
     it(`should return a geocoder interface which return a geocoder with
-      a given geocodeAddress function`, () => {
-        const mockGeocodeAddressFunction = () => {},
-          geocoderInterface = getGeocoderInterface(
-            null,
-            mockGeocodeAddressFunction
-          ),
-          geocoder = geocoderInterface.init(),
-          geocodeAddressFunction = geocoder.geocodeAddress;
-
-        should(geocodeAddressFunction).deepEqual(mockGeocodeAddressFunction);
-      }
-    );
+    a given geocodeAddress function`, () => {
+      const mockGeocodeAddressFunction = () => {},
+        geocoderInterface = getGeocoderInterface(
+          null,
+          mockGeocodeAddressFunction
+        ),
+        geocoder = geocoderInterface.init(),
+        geocodeAddressFunction = geocoder.geocodeAddress;
+      should(geocodeAddressFunction).deepEqual(mockGeocodeAddressFunction);
+    });
   });
 
   describe('getGeocodeFunction', () => {


### PR DESCRIPTION
The error messages currently returned assume that errors can only occur due to incorrect credentials.
This PR adds error messages for DNS errors, IP errors, and unknown errors.
