### PR TITLE
Require authentication via api key or client id

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ new GeoBatch({
 
 #### `clientId`
 
-Type `String`. The Google Maps Client ID, if you are using Google for Work. If this is passed in, the `privateKey` is also required. Default is `null`.
+Type `String`. The Google Maps Client ID, if you are using Google for Work. If this is passed in, the `privateKey` is also required.
+You must provide either a `clientId` and `privateKey`, or an `apiKey`. Default is `null`.
 
 #### `privateKey`
 
@@ -142,6 +143,7 @@ Type `String`. The Google Maps private key, if you are using Google for Work. If
 #### `apiKey`
 
 Type `String`. The Google Maps API key. If this is passed, neither `clientId` nor `privateKey` may be set.
+You must provide either a `clientId` and `privateKey`, or an `apiKey`.
 Default is `null`.
 
 #### `cacheFile`

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -11,6 +11,24 @@ const defaults = {
   apiKey: null
 };
 
+function validateOptions(options) {
+  if ((options.clientId || options.privateKey) && options.apiKey) {
+    throw new Error('Can only specify credentials or API key');
+  }
+
+  if (options.clientId && !options.privateKey) {
+    throw new Error('Missing privateKey');
+  }
+
+  if (!options.clientId && options.privateKey) {
+    throw new Error('Missing clientId');
+  }
+
+  if (!options.apiKey && !(options.clientId && options.privateKey)) {
+    throw new Error('Must either provide credentials or API key');
+  }
+}
+
 /**
  * Geocoder instance
  * @type {Class}
@@ -23,18 +41,7 @@ export default class Geocoder {
    */
   constructor(options = {}, geocoder = GoogleGeocoder, GeoCache = Cache) {
     options = Object.assign({}, defaults, options);
-
-    if ((options.clientId || options.privateKey) && options.apiKey) {
-      throw new Error('Can only specify credentials or API key');
-    }
-
-    if (options.clientId && !options.privateKey) {
-      throw new Error('Missing privateKey');
-    }
-
-    if (!options.clientId && options.privateKey) {
-      throw new Error('Missing clientId');
-    }
+    validateOptions(options);
 
     this.timeBetweenRequests =
       options.clientId && options.privateKey || options.apiKey ? 20 : 200;

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -11,6 +11,11 @@ const defaults = {
   apiKey: null
 };
 
+/**
+ * Validate a Geocoder options object
+ * This function throws an exception if the options are invalid
+ * @param {Object} options The options object to be validated
+ */
 function validateOptions(options) {
   if ((options.clientId || options.privateKey) && options.apiKey) {
     throw new Error('Can only specify credentials or API key');
@@ -43,10 +48,8 @@ export default class Geocoder {
     options = Object.assign({}, defaults, options);
     validateOptions(options);
 
-    this.timeBetweenRequests =
-      options.clientId && options.privateKey || options.apiKey ? 20 : 200;
+    this.timeBetweenRequests = 20;
     this.maxRequests = 20;
-
     this.lastGeocode = new Date();
     this.currentRequests = 0;
 

--- a/test/geocoder-test.js
+++ b/test/geocoder-test.js
@@ -2,7 +2,11 @@
 import should from 'should';
 import Geocoder from '../src/geocoder.js';
 import sinon from 'sinon';
-import {getGeocodeFunction, getGeocoderInterface} from './lib/helpers';
+import {
+  getGeocodeFunction,
+  getGeocoderInterface,
+  getGeocoderOptions
+} from './lib/helpers';
 
 class MockCache {
   constructor() {}
@@ -11,16 +15,6 @@ class MockCache {
 }
 
 describe('Testing geocoder', function() { // eslint-disable-line max-statements
-  it('should create a new instance when called without options', function() {
-    const geocoder = new Geocoder(
-      {},
-      getGeocoderInterface(),
-      MockCache
-    );
-
-    should.exist(geocoder);
-  });
-
   it('should create a cache', function() {
     const mackCacheFileName = 'a file name',
       mockCacheConstructor = sinon.stub();
@@ -33,7 +27,9 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
     }
 
     const geocoder = new Geocoder( // eslint-disable-line
-      {cacheFile: mackCacheFileName},
+      getGeocoderOptions({
+        cacheFile: mackCacheFileName
+      }),
       getGeocoderInterface(),
       NewMockCache
     );
@@ -112,7 +108,7 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
 
     const geoCoderInterface = getGeocoderInterface(geocodeFunction),
       geocoder = new Geocoder(
-        {},
+        getGeocoderOptions(),
         geoCoderInterface,
         MockCache
       );
@@ -126,10 +122,7 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
         geocodeFunction = getGeocodeFunction({results: ['some result']}),
         geoCoderInterface = getGeocoderInterface(geocodeFunction),
         geocoder = new Geocoder(
-          {
-            clientId: 'dummy',
-            privateKey: 'dummy'
-          },
+          getGeocoderOptions(),
           geoCoderInterface,
           MockCache
         );
@@ -198,10 +191,7 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
       }),
       geoCoderInterface = getGeocoderInterface(geocodeFunction),
       geocoder = new Geocoder(
-        {
-          clientId: 'dummy',
-          privateKey: 'dummy'
-        },
+        getGeocoderOptions(),
         geoCoderInterface,
         MockCache);
 
@@ -220,7 +210,7 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
       geocodeFunction = getGeocodeFunction({results: geoCoderResult}),
       geoCoderInterface = getGeocoderInterface(geocodeFunction),
       geocoder = new Geocoder(
-        {},
+        getGeocoderOptions(),
         geoCoderInterface,
         MockCache
       );
@@ -246,7 +236,7 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
     }
 
     const geocoder = new Geocoder(
-        {},
+        getGeocoderOptions(),
         geoCoderInterface,
         NewMockCache
       ),
@@ -273,7 +263,7 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
     }
 
     const geocoder = new Geocoder(
-        {},
+        getGeocoderOptions(),
         geoCoderInterface,
         NewMockCache
       ),
@@ -291,7 +281,7 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
       geocodeFunction = getGeocodeFunction({results: []}),
       geoCoderInterface = getGeocoderInterface(geocodeFunction),
       geocoder = new Geocoder(
-        {},
+        getGeocoderOptions(),
         geoCoderInterface,
         MockCache
       );

--- a/test/geocoder-test.js
+++ b/test/geocoder-test.js
@@ -15,6 +15,16 @@ class MockCache {
 }
 
 describe('Testing geocoder', function() { // eslint-disable-line max-statements
+  it('should require either credentials or an api key', function() {
+    should(() => {
+      const geocoder = new Geocoder( // eslint-disable-line no-unused-vars
+        {},
+        getGeocoderInterface(),
+        MockCache
+      );
+    }).throw('Must either provide credentials or API key');
+  });
+
   it('should create a cache', function() {
     const mackCacheFileName = 'a file name',
       mockCacheConstructor = sinon.stub();

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -7,14 +7,9 @@ import sinon from 'sinon';
 import streamAssert from 'stream-assert';
 
 import GeoBatch from '../src/index.js';
+import {getGeocoderOptions} from './lib/helpers.js';
 
 describe('Testing GeoBatch', () => {
-  it('should create a new instance when called without params', function() {
-    const geoBatch = new GeoBatch();
-
-    should.exist(geoBatch);
-  });
-
   it('should accept a clientId and a privateKey', function() {
     /* eslint-disable no-unused-vars */
     const MockGeoCoder = sinon.stub(),
@@ -53,14 +48,16 @@ describe('Testing GeoBatch', () => {
   it('should accept an accessor function', function() {
     /* eslint-disable no-unused-vars */
     const mockAccessor = sinon.stub(),
-      geoBatch = new GeoBatch({accessor: mockAccessor});
+      geoBatch = new GeoBatch(getGeocoderOptions({
+        accessor: mockAccessor
+      }));
 
     should(geoBatch.accessor).be.equal(mockAccessor);
   });
 
   it('should have a geocode function that accepts and returns a stream',
     function(done) {
-      const geoBatch = new GeoBatch();
+      const geoBatch = new GeoBatch(getGeocoderOptions());
 
       should(geoBatch.geocode).be.a.Function;
 
@@ -74,7 +71,7 @@ describe('Testing GeoBatch', () => {
 
   it('should call geocodeStream with correct stats when called with array',
     () => {
-      const geoBatch = new GeoBatch(),
+      const geoBatch = new GeoBatch(getGeocoderOptions()),
         geocodeStreamFunction = sinon.stub(),
         mockAddressArray = ['mock address'],
         expectedTotal = mockAddressArray.length,
@@ -91,7 +88,7 @@ describe('Testing GeoBatch', () => {
   );
 
   it('should transform an array to stream and pass it to geocodeStream', () => {
-    const geoBatch = new GeoBatch(),
+    const geoBatch = new GeoBatch(getGeocoderOptions()),
       geocodeStreamFunction = sinon.stub(),
       mockAddressArray = ['mock address'],
       expectedTotal = mockAddressArray.length,
@@ -109,7 +106,7 @@ describe('Testing GeoBatch', () => {
   });
 
   it('should accept a stream into geocode and pass it on', () => {
-    const geoBatch = new GeoBatch(),
+    const geoBatch = new GeoBatch(getGeocoderOptions()),
       geocodeStreamFunction = sinon.stub(),
       mockInputStream = intoStream.obj(['mock address']);
     geoBatch.geocodeStream = geocodeStreamFunction;
@@ -130,7 +127,9 @@ describe('Testing GeoBatch', () => {
       }
     }
     const mockGeoCoder = sinon.stub(),
-      geoBatch = new GeoBatch({}, mockGeoCoder, mockGeocodeStream),
+      geoBatch = new GeoBatch(getGeocoderOptions(),
+        mockGeoCoder,
+        mockGeocodeStream),
       mockAddress = 'some address',
       input = intoStream.obj([mockAddress]),
       resultStream = geoBatch.geocodeStream(input);
@@ -161,7 +160,9 @@ describe('Testing GeoBatch', () => {
     }
     const mockGeoCoder = sinon.stub(),
       geoBatch = new GeoBatch(
-        {accessor: mockAccessor},
+        getGeocoderOptions({
+          accessor: mockAccessor
+        }),
         mockGeoCoder,
         mockGeocodeStream
       ),

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -40,6 +40,20 @@ const helpers = {
   },
 
   /**
+   * Returns an options object for the Geocoder constructor with
+   * required default options added
+   * @param  {Object} opts desired extra options
+   * @return {Object}      input options, with added default options
+   */
+  getGeocoderOptions: opts => {
+    const defaultOptions = {
+      apiKey: 'dummy'
+    };
+
+    return Object.assign({}, defaultOptions, opts);
+  },
+
+  /**
    * Returns a mock geocoderStream.
    * @param  {Promise} geocoderPromise The geocode promise returned by the
    *                                   geocoder.


### PR DESCRIPTION
As of June 22nd 2016, the Google Geocoding API requires authentication via api key or clientId/privateKey pair
