### PR TITLE
feat(geobatch): add an option to specify maximum queries per second

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ new GeoBatch({
   privateKey: 'myPrivateKey',
   apiKey: 'myApiKey',
   cacheFile: 'myGeocache.db',
-  accessor: myAccessorFunction
+  accessor: myAccessorFunction,
+  queriesPerSecond: 50
 });
 ```
 
@@ -158,6 +159,11 @@ function(address) {
   return address;
 }
 ```
+
+#### `queriesPerSecond`
+
+Type `Number`. The maximum number of requests per second. This number must be between 1 and 50 (inclusive).
+Default is `50`.
 
 ## Contribution
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,4 @@
+export default {
+  maxQueriesPerSecond: 50,
+  minQueriesPerSecond: 1
+};

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -34,8 +34,8 @@ function validateOptions(options) { // eslint-disable-line complexity
     throw new Error('Must either provide credentials or API key');
   }
 
-  if (options.queriesPerSecond <= 0 || options.queriesPerSecond > 50) {
-    throw new Error('Requests per second must be > 0 and <= 50');
+  if (options.queriesPerSecond < 1 || options.queriesPerSecond > 50) {
+    throw new Error('Requests per second must be >= 1 and <= 50');
   }
 }
 

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -4,12 +4,13 @@ import Cache from './cache';
 import isEmpty from 'amp-is-empty';
 import GoogleGeocoder from './lib/google-geocoder';
 import Errors from './errors';
+import defaults from './defaults';
 
-const defaults = {
+const geocoderDefaults = {
   clientId: null,
   privateKey: null,
   apiKey: null,
-  queriesPerSecond: 50
+  queriesPerSecond: defaults.maxQueriesPerSecond
 };
 
 /**
@@ -34,7 +35,9 @@ function validateOptions(options) { // eslint-disable-line complexity
     throw new Error('Must either provide credentials or API key');
   }
 
-  if (options.queriesPerSecond < 1 || options.queriesPerSecond > 50) {
+  if (options.queriesPerSecond < defaults.minQueriesPerSecond ||
+    options.queriesPerSecond > defaults.maxQueriesPerSecond
+  ) {
     throw new Error('Requests per second must be >= 1 and <= 50');
   }
 }
@@ -50,7 +53,7 @@ export default class Geocoder {
    * @param  {Object} options Geocoder options.
    */
   constructor(options = {}, geocoder = GoogleGeocoder, GeoCache = Cache) {
-    options = Object.assign({}, defaults, options);
+    options = Object.assign({}, geocoderDefaults, options);
     validateOptions(options);
 
     this.timeBetweenRequests = Math.ceil(1000 / options.queriesPerSecond);

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -8,7 +8,8 @@ import Errors from './errors';
 const defaults = {
   clientId: null,
   privateKey: null,
-  apiKey: null
+  apiKey: null,
+  queriesPerSecond: 50
 };
 
 /**
@@ -16,7 +17,7 @@ const defaults = {
  * This function throws an exception if the options are invalid
  * @param {Object} options The options object to be validated
  */
-function validateOptions(options) {
+function validateOptions(options) { // eslint-disable-line complexity
   if ((options.clientId || options.privateKey) && options.apiKey) {
     throw new Error('Can only specify credentials or API key');
   }
@@ -31,6 +32,10 @@ function validateOptions(options) {
 
   if (!options.apiKey && !(options.clientId && options.privateKey)) {
     throw new Error('Must either provide credentials or API key');
+  }
+
+  if (options.queriesPerSecond <= 0 || options.queriesPerSecond > 50) {
+    throw new Error('Requests per second must be > 0 and <= 50');
   }
 }
 
@@ -48,7 +53,7 @@ export default class Geocoder {
     options = Object.assign({}, defaults, options);
     validateOptions(options);
 
-    this.timeBetweenRequests = 20;
+    this.timeBetweenRequests = Math.ceil(1000 / options.queriesPerSecond);
     this.maxRequests = 20;
     this.lastGeocode = new Date();
     this.currentRequests = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import intoStream from 'into-stream';
 import StandardGeocoder from './geocoder';
 import StandardGeocodeStream from './geocode-stream';
 import stream from 'stream';
+import defaults from './defaults';
 
 /**
  * GeoBatch instance
@@ -22,14 +23,14 @@ export default class GeoBatch {
       clientId = null,
       privateKey = null,
       apiKey = null,
-      queriesPerSecond = 50,
+      queriesPerSecond = defaults.maxQueriesPerSecond,
       accessor = address => address
     } = {
       cacheFile: 'geocache.db',
       clientId: null,
       privateKey: null,
       apiKey: null,
-      queriesPerSecond: 50,
+      queriesPerSecond: defaults.maxQueriesPerSecond,
       accessor: address => address
     },
     Geocoder = StandardGeocoder,

--- a/src/index.js
+++ b/src/index.js
@@ -22,18 +22,26 @@ export default class GeoBatch {
       clientId = null,
       privateKey = null,
       apiKey = null,
+      queriesPerSecond = 50,
       accessor = address => address
     } = {
       cacheFile: 'geocache.db',
       clientId: null,
       privateKey: null,
       apiKey: null,
+      queriesPerSecond: 50,
       accessor: address => address
     },
     Geocoder = StandardGeocoder,
     GeocodeStream = StandardGeocodeStream
   ) {
-    this.geocoder = new Geocoder({cacheFile, clientId, privateKey, apiKey});
+    this.geocoder = new Geocoder({
+      cacheFile,
+      clientId,
+      privateKey,
+      apiKey,
+      queriesPerSecond
+    });
     this.GeocodeStream = GeocodeStream;
     this.accessor = accessor;
   }

--- a/test/geocoder-test.js
+++ b/test/geocoder-test.js
@@ -123,6 +123,36 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
     should.exist(geocoder);
   });
 
+  it('should not accept less than 1 query per second', function() {
+    should(() => {
+      const geocoder = new Geocoder( // eslint-disable-line no-unused-vars
+        getGeocoderOptions({queriesPerSecond: 0.5}),
+        getGeocoderInterface(),
+        MockCache
+      );
+    }).throw('Requests per second must be >= 1 and <= 50');
+  });
+
+  it('should not accept negative queries per second', function() {
+    should(() => {
+      const geocoder = new Geocoder( // eslint-disable-line no-unused-vars
+        getGeocoderOptions({queriesPerSecond: -2}),
+        getGeocoderInterface(),
+        MockCache
+      );
+    }).throw('Requests per second must be >= 1 and <= 50');
+  });
+
+  it('should not accept less more than 50 queries per second', function() {
+    should(() => {
+      const geocoder = new Geocoder( // eslint-disable-line no-unused-vars
+        getGeocoderOptions({queriesPerSecond: 51}),
+        getGeocoderInterface(),
+        MockCache
+      );
+    }).throw('Requests per second must be >= 1 and <= 50');
+  });
+
   it('should return a promise from the geocodeAddress function', () => {
     const geocodeFunction = getGeocodeFunction({error: 'error'});
 

--- a/test/geocoder-test.js
+++ b/test/geocoder-test.js
@@ -113,6 +113,16 @@ describe('Testing geocoder', function() { // eslint-disable-line max-statements
     }).throw('Can only specify credentials or API key');
   });
 
+  it('should accept a maximum requests per second option', function() {
+    const geocoder = new Geocoder(
+      getGeocoderOptions({queriesPerSecond: 10}),
+      getGeocoderInterface(),
+      MockCache
+    );
+
+    should.exist(geocoder);
+  });
+
   it('should return a promise from the geocodeAddress function', () => {
     const geocodeFunction = getGeocodeFunction({error: 'error'});
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -17,7 +17,8 @@ describe('Testing GeoBatch', () => {
         cacheFile: 'geocache.db',
         clientId: null,
         privateKey: null,
-        apiKey: null
+        apiKey: null,
+        queriesPerSecond: 50
       },
       options = {clientId: 'a clientID', privateKey: 'a privateKey'},
       geoBatch = new GeoBatch(options, MockGeoCoder);
@@ -35,12 +36,31 @@ describe('Testing GeoBatch', () => {
         cacheFile: 'geocache.db',
         clientId: null,
         privateKey: null,
-        apiKey: null
+        apiKey: null,
+        queriesPerSecond: 50
       },
       options = {apiKey: 'an apiKey'},
       geoBatch = new GeoBatch(options, MockGeoCoder);
 
     expectedOptions.apiKey = 'an apiKey';
+
+    sinon.assert.calledWith(MockGeoCoder, expectedOptions);
+  });
+
+  it('should accept a number of maximum queries per second', function() {
+    /* eslint-disable no-unused-vars */
+    const MockGeoCoder = sinon.stub(),
+      expectedOptions = {
+        cacheFile: 'geocache.db',
+        clientId: null,
+        privateKey: null,
+        apiKey: null,
+        queriesPerSecond: 25
+      },
+      options = getGeocoderOptions({queriesPerSecond: 25}),
+      geoBatch = new GeoBatch(options, MockGeoCoder);
+
+    expectedOptions.apiKey = options.apiKey;
 
     sinon.assert.calledWith(MockGeoCoder, expectedOptions);
   });


### PR DESCRIPTION
This PR adds an option to specify the maximum number of requests per second.
I am not too happy about the `eslint-disable-line complexity` in `validateOptions` in `src/geocoder.js`.
Can anyone think of a nicer solution for this?
