### PR TITLE
chore: update dependencies and add license field to package.json

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,15 @@
   "env": {
     "browser": true,
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "es6": true
   },
   "globals": {
     "google": true,
     "cartodb": true
+  },
+  "parserOptions": {
+    "sourceType": "module"
   },
   "ecmaFeatures": {
     "arrowFunctions": true,
@@ -76,7 +80,6 @@
     "no-caller": 2,
     "no-div-regex": 1,
     "no-else-return": 2,
-    "no-empty-label": 2,
     "no-eq-null": 2,
     "no-eval": 2,
     "no-extend-native": 2,
@@ -194,11 +197,9 @@
     }],
     "sort-vars": 0,
     "space-before-function-paren": [2, "never"],
-    "space-after-keywords": [2, "always"],
     "space-before-blocks": [2, "always"],
     "space-in-parens": [2, "never"],
     "space-infix-ops": 2,
-    "space-return-throw-case": 2,
     "space-unary-ops": [2, {
       "words": true,
       "nonwords": false
@@ -213,7 +214,7 @@
       "before": true,
       "after": false
     }],
-
+    "keyword-spacing": 2,
     "max-depth": [1, 3],
     "max-len": [2, 80, 2],
     "max-params": [2, 4],

--- a/.release.json
+++ b/.release.json
@@ -9,8 +9,9 @@
   "tagName": "%s",
   "tagAnnotation": "Release %s",
   "buildCommand": "npm run changelog",
-  "distRepo": false,
-  "private": false,
-  "publish": true,
-  "publishPath": "."
+  "npm": {
+    "private": false,
+    "publish": true,
+    "publishPath": "."
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublish": "npm run lint && npm run build",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-core/register",
-    "generatechangelog": "conventional-changelog-generator",
+    "generatechangelog": "conventional-changelog -i CHANGELOG.md -s -p angular",
     "commitchangelog": "git add CHANGELOG.md && git commit -m \"chore(changelog): new version\" && git push origin master",
     "changelog": "npm run generatechangelog && git reset package.json && npm run commitchangelog && git add package.json",
     "release": "git reset && release-it",
@@ -38,21 +38,19 @@
   "dependencies": {
     "amp-is-empty": "^1.0.2",
     "cyclist": "^1.0.1",
-    "flat-file-db": "^0.1.4",
+    "flat-file-db": "^1.0.0",
     "googlemaps": "^1.6.0",
     "into-stream": "^2.0.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
-    "conventional-changelog-generator": "0.0.3",
-    "eslint": "^1.6.0",
-    "into-stream": "^2.0.0",
+    "conventional-changelog-cli": "^1.2.0",
+    "eslint": "^3.0.1",
     "lie": "^3.0.1",
-    "mocha": "2.1.0",
+    "mocha": "^2.5.0",
     "release-it": "0.0.15",
-    "should": "^7.1.0",
-    "should-promised": "^0.1.0",
+    "should": "^9.0.0",
     "sinon": "^1.17.1",
     "stream-assert": "^2.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint": "^3.0.1",
     "lie": "^3.0.1",
     "mocha": "^2.5.0",
-    "release-it": "0.0.15",
+    "release-it": "^2.4.0",
     "should": "^9.0.0",
     "sinon": "^1.17.1",
     "stream-assert": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
     "conventional-changelog-cli": "^1.2.0",
-    "eslint": "^3.0.1",
+    "eslint": "^2.13.1",
     "lie": "^3.0.1",
     "mocha": "^2.5.0",
     "release-it": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "geobatch",
   "description": "Batch geocode addresses from multiple sources.",
   "version": "1.4.1",
+  "license": "MIT",
   "author": {
     "name": "Robert Katzki",
     "email": "katzki@ubilabs.net",

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -51,7 +51,9 @@ function validateOptions(options) { // eslint-disable-line complexity
 export default class Geocoder {
   /**
    * Constructs a geocoder.
-   * @param  {Object} options Geocoder options.
+   * @param {Object} options Geocoder options.
+   * @param {Object} geocoder The Google geocoding API class
+   * @param {Object} GeoCache The Cache class
    */
   constructor(options = {}, geocoder = GoogleGeocoder, GeoCache = Cache) {
     options = Object.assign({}, geocoderDefaults, options);
@@ -86,6 +88,7 @@ export default class Geocoder {
    * @param {String} address The address to geocode
    * @param {Function} resolve The Promise resolve function
    * @param {Function} reject The Promise reject function
+   * @param {Number} retries The number of times this query has been tried
    * @return {?} Something to get out
    */
   queueGeocode(address, resolve, reject, retries = 0) {
@@ -103,6 +106,7 @@ export default class Geocoder {
 
     this.queries++;
     this.startGeocode(address, resolve, reject, retries);
+    return null;
   }
 
   /**
@@ -133,6 +137,7 @@ export default class Geocoder {
    * @param {String} address The address to geocode
    * @param {Function} resolve The Promise resolve function
    * @param {Function} reject The Promise reject function
+   * @param {Number} retries The number of times this query has been tried
    */
   startGeocode(address, resolve, reject, retries = 0) {
     const geoCodeParams = {

--- a/src/lib/google-geocoder.js
+++ b/src/lib/google-geocoder.js
@@ -10,7 +10,7 @@ export default class GoogleGeocoder {
 
   /**
    * Inits a google maps API instance with give clientID and privateKey.
-   * @param  {Object}             Config Object
+   * @param  {Object} options     Config Object
    * @return {Object}             Instance of google maps API
    */
   static init(options = {}) {

--- a/src/lib/parallel-transform.js
+++ b/src/lib/parallel-transform.js
@@ -77,6 +77,7 @@ export default class ParallelTransform extends stream.Transform {
 
     // otherwise wait until a transformation finished
     this.ondrain = done;
+    return null;
   }
 
   /**

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -25,7 +25,9 @@ const helpers = {
    * Returns a geocoder interface. The init function returns a geocoder that
    * exposes a geocode function.
    * @param  {Function} geocodeFunction The geocode function to be exposed.
-   * @return {Object}                 A geocoder interface object.
+   * @param  {Function} geocodeAddressFunction The geocodeAddress function
+                                               to be exposed
+   * @return {Object}                   A geocoder interface object.
    */
   getGeocoderInterface: (
     geocodeFunction = () => {},


### PR DESCRIPTION
This PR updates most of the dependencies, removes a duplicate dependency, and adds a license field to `package.json`.
I am unable to test whether or not the update of `release-it` in 4b46625 breaks anything.
However, the currently used version of `release-it` is very outdated, and will not work with node v7. We will have to update it at some point anyways.
