### PR TITLE
fix(geocode-stream): fix a bug with low QPS limits

### DIFF
--- a/src/geocode-stream.js
+++ b/src/geocode-stream.js
@@ -1,5 +1,4 @@
 import ParallelTransform from './lib/parallel-transform';
-import defaults from './defaults';
 
 /**
  * A streaming object for the geocode
@@ -9,13 +8,18 @@ export default class GeocodeStream extends ParallelTransform {
   /**
    * Constructs a geocodeStream.
    * @param  {Object} geocoder A geocoder.
+   * @param  {Number} queriesPerSecond The number of queries per second
    * @param  {Object} stats A statistics object.
    * @param  {Function} accessor An accessor function that returns the address
    *                             from the data item. The default returns the
    *                             data item directly.
    */
-  constructor(geocoder, stats, accessor = address => address) {
-    super(defaults.maxQueriesPerSecond, {objectMode: true});
+  constructor(geocoder,
+    queriesPerSecond,
+    stats,
+    accessor = address => address
+  ) {
+    super(queriesPerSecond, {objectMode: true});
 
     this.geocoder = geocoder;
     this.stats = stats;

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export default class GeoBatch {
     });
     this.GeocodeStream = GeocodeStream;
     this.accessor = accessor;
+    this.queriesPerSecond = queriesPerSecond;
   }
 
   /**
@@ -80,6 +81,7 @@ export default class GeoBatch {
   geocodeStream(inputStream, stats = {current: 0}) {
     const geocodeStream = new this.GeocodeStream(
       this.geocoder,
+      this.queriesPerSecond,
       stats,
       this.accessor
     );

--- a/test/geocode-stream-test.js
+++ b/test/geocode-stream-test.js
@@ -38,14 +38,14 @@ describe('Geocode Stream', () => {
   });
 
   it('should take an accessor function', function() {
-    const mockAcessor = sinon.stub(),
+    const mockAccessor = sinon.stub(),
       geocodeStream = new GeocodeStream(null,
         defaults.defaultQueriesPerSecond,
         null,
-        mockAcessor
+        mockAccessor
       );
 
-    should(geocodeStream.accessor).equal(mockAcessor);
+    should(geocodeStream.accessor).equal(mockAccessor);
   });
 
   describe('_transform should', () => {

--- a/test/geocode-stream-test.js
+++ b/test/geocode-stream-test.js
@@ -6,6 +6,7 @@ import stream from 'stream';
 import intoStream from 'into-stream';
 import streamAssert from 'stream-assert';
 import Promise from 'lie';
+import defaults from '../src/defaults';
 
 import GeocodeStream from '../src/geocode-stream';
 import {getGeocodeStream, getGeocoderInterface} from './lib/helpers';
@@ -29,13 +30,20 @@ describe('Geocode Stream', () => {
 
   it('should take stats', () => {
     const mockStats = 'some stats',
-      geocodeStream = new GeocodeStream(null, mockStats);
+      geocodeStream = new GeocodeStream(null,
+        defaults.defaultQueriesPerSecond,
+        mockStats
+      );
     should(geocodeStream.stats).be.equal(mockStats);
   });
 
   it('should take an accessor function', function() {
     const mockAcessor = sinon.stub(),
-      geocodeStream = new GeocodeStream(null, null, mockAcessor);
+      geocodeStream = new GeocodeStream(null,
+        defaults.defaultQueriesPerSecond,
+        null,
+        mockAcessor
+      );
 
     should(geocodeStream.accessor).equal(mockAcessor);
   });
@@ -100,7 +108,11 @@ describe('Geocode Stream', () => {
           newGeocodeAddressFunction
         ),
         geocoder = GeoCoderInterface.init(),
-        geocodeStream = new GeocodeStream(geocoder, null, accessorFunction);
+        geocodeStream = new GeocodeStream(geocoder,
+          defaults.defaultQueriesPerSecond,
+          null,
+          accessorFunction
+        );
 
       geocodeStream._transform(mockInput, null, () => {});
       promise

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -157,8 +157,8 @@ describe('Testing GeoBatch', () => {
 
     // Create a mock geocode-stream class that passes elements unchanged.
     class mockGeocodeStream extends ParallelTransform {
-      constructor(geocoder, stats, accessor) {
-        super(1, {objectMode: true});
+      constructor(geocoder, queriesPerSecond, stats, accessor) {
+        super(queriesPerSecond, {objectMode: true});
         should(accessor).equal(mockAccessor);
         done();
       }

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 import GeocodeStream from '../../src/geocode-stream';
 import ParallelTransform from '../../src/lib/parallel-transform';
+import defaults from '../../src/defaults';
 
 const helpers = {
   /**
@@ -55,7 +56,7 @@ const helpers = {
       privateKey: null,
       apiKey: 'dummy',
       maxRetries: 0,
-      queriesPerSecond: 35
+      queriesPerSecond: defaults.defaultQueriesPerSecond
     };
 
     return Object.assign({}, defaultOptions, opts);
@@ -65,9 +66,13 @@ const helpers = {
    * Returns a mock geocoderStream.
    * @param  {Promise} geocoderPromise The geocode promise returned by the
    *                                   geocoder.
+   * @param  {Number} queriesPerSecond The queries per second
    * @return {Stream} A mock geocoder stream.-
    */
-  getGeocodeStream: geocoderPromise => {
+  getGeocodeStream: (
+    geocoderPromise,
+    queriesPerSecond = defaults.defaultQueriesPerSecond
+  ) => {
     const mockGeocodeAddressFunction = () => geocoderPromise,
       GeoCoderInterface = helpers.getGeocoderInterface(
         null,
@@ -75,7 +80,7 @@ const helpers = {
       ),
       mockGeocoder = GeoCoderInterface.init(),
       mockStats = {};
-    return new GeocodeStream(mockGeocoder, mockStats);
+    return new GeocodeStream(mockGeocoder, queriesPerSecond, mockStats);
   },
 
   /**


### PR DESCRIPTION
This PR fixes an issue were a QPS limit of 1 would cause the node transform stream to prematurely call "flush" after a certain number of geocodes, and thereby quit the geocoding process before it was finished
