### PR TITLE
fix(geocode-stream): ensure sequential order in 'current' field

### DIFF
--- a/src/geocode-stream.js
+++ b/src/geocode-stream.js
@@ -16,7 +16,7 @@ export default class GeocodeStream extends ParallelTransform {
    */
   constructor(geocoder,
     queriesPerSecond,
-    stats,
+    stats = {current: 0},
     accessor = address => address
   ) {
     super(queriesPerSecond, {objectMode: true});
@@ -32,17 +32,16 @@ export default class GeocodeStream extends ParallelTransform {
    * @param {Function} done The done callback function
    */
   _parallelTransform(input, done) { // eslint-disable-line
+    const data = this.getMetaInfo(input);
+
     this.geocoder.geocodeAddress(this.accessor(input))
       .then(results => {
-        let data = this.getMetaInfo(input);
         data.result = results[0];
         data.results = results;
         data.location = results[0].geometry.location;
         done(null, data);
       })
       .catch(error => {
-        let data = this.getMetaInfo(input);
-
         data.error = error.message;
         done(null, data);
       });

--- a/test/geocode-stream-test.js
+++ b/test/geocode-stream-test.js
@@ -110,7 +110,7 @@ describe('Geocode Stream', () => {
         geocoder = GeoCoderInterface.init(),
         geocodeStream = new GeocodeStream(geocoder,
           defaults.defaultQueriesPerSecond,
-          null,
+          {},
           accessorFunction
         );
 


### PR DESCRIPTION
Using the parallel structure introduced a bug where the 'current' field might not ascend in sequential order for QPS > 1.
